### PR TITLE
Add Connection Kind for Dynamic Fracturing

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -81,6 +81,7 @@ namespace Opm {
         enum class CTFKind {
             DeckValue,
             Defaulted,
+            DynamicFracturing,
         };
 
 

--- a/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/opm/output/eclipse/AggregateConnectionData.cpp
@@ -70,6 +70,11 @@ namespace {
 
         std::size_t connID = 0;
         for (const auto* connPtr : well.getConnections().output(grid)) {
+            if (connPtr->kind() == Opm::Connection::CTFKind::DynamicFracturing) {
+                // Don't emit, or count, connections created by dynamic fracturing.
+                continue;
+            }
+
             const auto* dynConnRes = (wellRes == nullptr)
                 ? nullptr : wellRes->find_connection(connPtr->global_index());
 

--- a/opm/output/eclipse/AggregateWellData.cpp
+++ b/opm/output/eclipse/AggregateWellData.cpp
@@ -38,6 +38,7 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
@@ -467,6 +468,38 @@ namespace {
         }
 
         template <class IWellArray>
+        void captureWellConnections(const bool                  isMsw,
+                                    const Opm::WellConnections& conns,
+                                    IWellArray&                 iWell)
+        {
+            using Ix = VI::IWell::index;
+
+            auto isRegularConn = [](const Opm::Connection& conn)
+            { return conn.kind() != Opm::Connection::CTFKind::DynamicFracturing; };
+
+            iWell[Ix::NConn] = std::count_if(conns.begin(), conns.end(), isRegularConn);
+
+            if (isMsw || (iWell[Ix::NConn] == 0)) {
+                // Set top and bottom connections to zero for multi
+                // segment wells or if there are no connections at all.
+                iWell[Ix::FirstK] = iWell[Ix::LastK] = 0;
+            }
+            else {
+                auto firstPos = std::find_if(conns.begin(), conns.end(), isRegularConn);
+
+                auto lastPos  = std::find_if(std::make_reverse_iterator(conns.end()),
+                                             std::make_reverse_iterator(conns.begin()),
+                                             isRegularConn);
+
+                assert (firstPos != conns.end());
+                assert (lastPos  != std::make_reverse_iterator(conns.begin()));
+
+                iWell[Ix::FirstK] = firstPos->getK() + 1;
+                iWell[Ix::LastK]  = lastPos ->getK() + 1;
+            }
+        }
+
+        template <class IWellArray>
         void staticContrib(const Opm::Well&                well,
                            const Opm::GasLiftOpt&          glo,
                            const Opm::WellTestConfig&      wtest_config,
@@ -482,26 +515,7 @@ namespace {
             iWell[Ix::JHead] = well.getHeadJ() + 1;
             iWell[Ix::Status] = wellStatus(well.getStatus());
 
-            // Connections
-            {
-                const auto& conn = well.getConnections();
-
-                iWell[Ix::NConn]  = static_cast<int>(conn.size());
-
-                if (well.isMultiSegment()) {
-                    // Set top and bottom connections to zero for multi
-                    // segment wells
-                    iWell[Ix::FirstK] = 0;
-                    iWell[Ix::LastK]  = 0;
-                }
-                else {
-                    iWell[Ix::FirstK] = (iWell[Ix::NConn] == 0)
-                        ? 0 : conn.get(0).getK() + 1;
-
-                    iWell[Ix::LastK] = (iWell[Ix::NConn] == 0)
-                        ? 0 : conn.get(conn.size() - 1).getK() + 1;
-                }
-            }
+            captureWellConnections(well.isMultiSegment(), well.getConnections(), iWell);
 
             iWell[Ix::Group] =
                 groupIndex(trim(well.groupName()), GroupMapNameInd);


### PR DESCRIPTION
This enables filtering connections arising from dynamic fracturing processes out of the restart file handling.  These connections often create confusing displays in post-processing tools like ResInsight and, equally important, may lead to problems in restarted simulation runs.

For now we apply a heavy-handed approach that just removes all connections tagged as "DynamicFracturing" when creating the restart files.  We may be more permissive in the future if the need arises.