### PR TITLE
Restore Tests Build

### DIFF
--- a/opm/input/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.cpp
@@ -304,6 +304,9 @@ namespace Opm {
         return this->getDataRecord().getDataItem().getData< std::string >();
     }
 
+    std::vector<double>& DeckKeyword::getRawDoubleData() {
+        return this->getRecord(0).getItem(0).getData<double>();
+    }
 
     const std::vector<double>& DeckKeyword::getRawDoubleData() const {
         return this->getDataRecord().getDataItem().getData< double >();

--- a/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
@@ -200,22 +200,22 @@ namespace Opm {
         return this->stress_yz_grad;
     }
 
-    bool StressEquilRecord::operator==(const StressEquilRecord& data) const {
-        return datum_depth == data.datum_depth &&
-               datum_posx == data.datum_posx &&
-               datum_posy == data.datum_posy &&
-               stress_xx == data.stress_xx &&
-               stress_xx_grad == data.stress_xx_grad &&
-               stress_yy == data.stress_yy &&
-               stress_yy_grad == data.stress_yy_grad &&
-               stress_zz == data.stress_zz &&
-               stress_zz_grad == data.stress_zz_grad &&
-               stress_xy_grad == data.stress_xy &&
-               stress_xy_grad == data.stress_xy_grad &&
-               stress_xz == data.stress_xz &&
-               stress_xz_grad == data.stress_xz_grad &&
-               stress_yz == data.stress_yz &&
-               stress_yz_grad == data.stress_yz_grad;
+    bool StressEquilRecord::operator==(const StressEquilRecord& data) const
+    {
+        return (datum_depth == data.datum_depth)
+            && (datum_posx == data.datum_posx)
+            && (datum_posy == data.datum_posy)
+
+            // Diagonal terms
+            && (stress_xx == data.stress_xx) && (stress_xx_grad == data.stress_xx_grad)
+            && (stress_yy == data.stress_yy) && (stress_yy_grad == data.stress_yy_grad)
+            && (stress_zz == data.stress_zz) && (stress_zz_grad == data.stress_zz_grad)
+
+            // Cross terms
+            && (stress_xy == data.stress_xy) && (stress_xy_grad == data.stress_xy_grad)
+            && (stress_xz == data.stress_xz) && (stress_xz_grad == data.stress_xz_grad)
+            && (stress_yz == data.stress_yz) && (stress_yz_grad == data.stress_yz_grad)
+            ;
     }
 
     /* ----------------------------------------------------------------- */

--- a/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -109,8 +109,6 @@ namespace Opm {
                 serializer(stress_xz_grad);
                 serializer(stress_yz);
                 serializer(stress_yz_grad);
-
-
             }
 
         private:
@@ -130,8 +128,6 @@ namespace Opm {
             double stress_xz_grad = 0.0;
             double stress_yz = 0.0;
             double stress_yz_grad = 0.0;
-
-            
     };
 
     template<class RecordType>

--- a/opm/input/eclipse/Schedule/Well/WellFractureSeeds.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellFractureSeeds.cpp
@@ -28,8 +28,7 @@
 
 bool Opm::WellFractureSeeds::updateSeed(const std::size_t   seedCellGlobal,
                                         const NormalVector& seedNormal,
-					const SizeVector& seedSize
-					)
+                                        const SizeVector&   seedSize)
 {
     const auto ix = this->seedIndex(seedCellGlobal);
 
@@ -88,7 +87,7 @@ Opm::WellFractureSeeds Opm::WellFractureSeeds::serializationTestObject()
 
     s.seedCell_.push_back(1729);
     s.seedNormal_.push_back({ 1.1, -2.2, 3.3 });
-    s.seedSize_.push_back({ 1.1, 2.2});
+    s.seedSize_.push_back({ 1.1, 2.2 });
     s.lookup_.push_back(0);
 
     return s;
@@ -156,7 +155,7 @@ Opm::WellFractureSeeds::seedIndexLinearSearch(const std::size_t seedCellGlobal) 
 
 bool Opm::WellFractureSeeds::insertNewSeed(const std::size_t   seedCellGlobal,
                                            const NormalVector& seedNormal,
-					   const SizeVector& seedSize)
+                                           const SizeVector&   seedSize)
 {
     this->seedCell_.push_back(seedCellGlobal);
     this->seedNormal_.push_back(seedNormal);
@@ -168,16 +167,15 @@ bool Opm::WellFractureSeeds::insertNewSeed(const std::size_t   seedCellGlobal,
 
 bool Opm::WellFractureSeeds::updateExistingSeed(const NormalVectorIx ix,
                                                 const NormalVector&  seedNormal,
-						const SizeVector&  seedSize
-						)
+                                                const SizeVector&    seedSize)
 {
-    auto isDifferent = this->seedNormal_[ix] != seedNormal;
+    const auto isDifferent =
+        (this->seedNormal_[ix] != seedNormal) ||
+        (this->seedSize_  [ix] != seedSize)
+        ;
 
     this->seedNormal_[ix] = seedNormal;
+    this->seedSize_  [ix] = seedSize;
 
-    isDifferent = isDifferent || this->seedSize_[ix] != seedSize;
-    
-    this->seedSize_[ix] = seedSize;
-    
     return isDifferent;
 }

--- a/opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp
@@ -82,11 +82,13 @@ public:
     /// a unit normal as far as class WellFractureSeeds goes, but subsequent
     /// uses may prefer unit normals.
     ///
+    /// \param[in] seedSize Fracturing plane's initial size.
+    ///
     /// \return Whether or not a seed was inserted/updated.  Typically
     /// 'true'.
     bool updateSeed(const std::size_t   seedCellGlobal,
                     const NormalVector& seedNormal,
-		    const SizeVector& seedSize);
+                    const SizeVector&   seedSize);
 
     /// Establish accelerator structure for LOG(n) normal vector lookup
     /// based on Cartesian cell indices.
@@ -119,8 +121,8 @@ public:
     ///
     /// \param[in] c Cartesian cell index.
     ///
-    /// \return Fracturing plane normal vector in cell \p c.  Not guaranteed
-    /// to be a unit normal vector.  Nullptr if no seed exists in cell \p c.
+    /// \return Fracturing plane size vector in cell \p c.  Nullptr if no
+    /// seed exists in cell \p c.
     const SizeVector* getSize(const SeedCell& c) const;
 
     /// Retrieve fracturing plane normal vector based on insertion
@@ -171,6 +173,7 @@ public:
         serializer(this->wellName_);
         serializer(this->seedCell_);
         serializer(this->seedNormal_);
+        serializer(this->seedSize_);
         serializer(this->lookup_);
     }
 
@@ -241,9 +244,13 @@ private:
     ///
     /// \param[in] seedNormal Fracturing plane's normal vector.
     ///
+    /// \param[in] seedSize Fracturing plane's initial size.
+    ///
     /// \return Whether or not a seed was inserted/updated.  Typically
     /// 'true'.
-  bool insertNewSeed(const std::size_t seedCellGlobal, const NormalVector& seedNormal, const SizeVector& seedSize);
+    bool insertNewSeed(const std::size_t   seedCellGlobal,
+                       const NormalVector& seedNormal,
+                       const SizeVector&   seedSize);
 
     /// Update normal vector direction of an existing seed cell.
     ///
@@ -252,8 +259,12 @@ private:
     ///
     /// \param[in] seedNormal Fracturing plane's normal vector.
     ///
+    /// \param[in] seedSize Fracturing plane's initial size.
+    ///
     /// \return Whether or not the normal vector for seed \p ix was updated.
-  bool updateExistingSeed(const NormalVectorIx ix, const NormalVector& seedNormal, const SizeVector& seedSize);
+    bool updateExistingSeed(const NormalVectorIx ix,
+                            const NormalVector&  seedNormal,
+                            const SizeVector&    seedSize);
 };
 
 } // namespace Opm

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -6546,9 +6546,9 @@ END
     }
 }
 
-BOOST_AUTO_TEST_CASE(Well_Fracture_Seeds_No_MECH)
+BOOST_AUTO_TEST_CASE(Well_Fracture_Seeds_With_Size)
 {
-    const auto inputString = std::string { R"(RUNSPEC
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
 DIMENS
   10 10 10 /
 
@@ -6600,24 +6600,46 @@ DATES             -- 1, 2
 /
 
 WSEED
-  'OP_1'  9 9 1   1.0   -1.0      1.0  /
-  'OP_1'  9 9 2   0.0    0.0     17.29 /
-  'OP_3'  7 7 2   3.1   41.592  653.5  /
+  'OP_1'  9 9 1   1.0   -1.0      1.0  0.12 34.567 /
+  'OP_1'  9 9 2   0.0    0.0     17.29 8.91 0.111 /
+  'OP_3'  7 7 2   3.1   41.592  653.5  12.13 14.151617 /
 /
 
 DATES
   1 SEP 2007 /
 /
 END
-)" };
+)");
 
-    // No MECH keyword means that parsing, by default, should fail in WSEED.
-    BOOST_CHECK_THROW(Parser().parseString(inputString), OpmInputError);
+    const auto es    = EclipseState { deck };
+    const auto sched = Schedule { deck, es };
 
-    auto ctx = ParseContext{};
-    ctx.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION,
-               InputErrorAction::IGNORE);
+    const auto& wseed = sched[2].wseed;
 
-    // Allow parsing the input if we ignore incompatible keywords.
-    BOOST_CHECK_NO_THROW(Parser().parseString(inputString, ctx));
+    {
+        const auto& op_1 = wseed("OP_1");
+
+        const auto& seedCells = op_1.seedCells();
+
+        const auto* s0 = op_1.getSize(WellFractureSeeds::SeedCell { seedCells[0] });
+
+        BOOST_CHECK_CLOSE((*s0)[0],  0.12 , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s0)[1], 34.567, 1.0e-8);
+
+        const auto* s1 = op_1.getSize(WellFractureSeeds::SeedCell { seedCells[1] });
+
+        BOOST_CHECK_CLOSE((*s1)[0], 8.91 , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s1)[1], 0.111, 1.0e-8);
+    }
+
+    {
+        const auto& op_3 = wseed("OP_3");
+
+        const auto& seedCells = op_3.seedCells();
+
+        const auto* s = op_3.getSize(WellFractureSeeds::SeedCell { seedCells[0] });
+
+        BOOST_CHECK_CLOSE((*s)[0], 12.13    , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 14.151617, 1.0e-8);
+    }
 }

--- a/tests/test_WellFractureSeeds.cpp
+++ b/tests/test_WellFractureSeeds.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 
 using NormalVector = Opm::WellFractureSeeds::NormalVector;
+using SizeVector = Opm::WellFractureSeeds::SizeVector;
 
 BOOST_AUTO_TEST_SUITE(Insert_Unique)
 
@@ -38,7 +39,7 @@ BOOST_AUTO_TEST_CASE(Single_Seed)
     BOOST_CHECK_EQUAL(seeds.name(), "W1");
     BOOST_CHECK_MESSAGE(seeds.empty(), "Default constructed WellFractureSeeds object must be empty");
 
-    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }),
+    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.1, 2.2 }),
                         "Inserting into empty collection must succeed");
 
     BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
@@ -58,6 +59,14 @@ BOOST_AUTO_TEST_CASE(Single_Seed)
         BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
         BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.1, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.2, 1.0e-8);
     }
 
     {
@@ -99,7 +108,7 @@ BOOST_AUTO_TEST_CASE(Single_Seed)
 BOOST_AUTO_TEST_CASE(Copy_Constructor)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.1, 2.2 });
 
     const auto s2 = seeds;
 
@@ -125,6 +134,14 @@ BOOST_AUTO_TEST_CASE(Copy_Constructor)
     }
 
     {
+        const auto* s = s2.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.1, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.2, 1.0e-8);
+    }
+
+    {
         const auto& c = s2.seedCells();
         const auto expect = std::vector { std::size_t{1729} };
 
@@ -135,7 +152,7 @@ BOOST_AUTO_TEST_CASE(Copy_Constructor)
 BOOST_AUTO_TEST_CASE(Move_Constructor)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.7, 2.9 });
 
     const auto s2 = std::move(seeds);
 
@@ -159,6 +176,14 @@ BOOST_AUTO_TEST_CASE(Move_Constructor)
     }
 
     {
+        const auto* s = s2.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.7, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.9, 1.0e-8);
+    }
+
+    {
         const auto& c = s2.seedCells();
         const auto expect = std::vector { std::size_t{1729} };
 
@@ -169,10 +194,10 @@ BOOST_AUTO_TEST_CASE(Move_Constructor)
 BOOST_AUTO_TEST_CASE(Assignment_Operator)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.1, 2.2 });
 
     auto s2 = Opm::WellFractureSeeds { "W2" };
-    s2.updateSeed(2718, NormalVector { 0.0, -1.0, 0.0 });
+    s2.updateSeed(2718, NormalVector { 0.0, -1.0, 0.0 }, SizeVector { 3.3, 4.4 });
 
     s2 = seeds;
 
@@ -198,6 +223,14 @@ BOOST_AUTO_TEST_CASE(Assignment_Operator)
     }
 
     {
+        const auto* s = s2.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.1, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.2, 1.0e-8);
+    }
+
+    {
         const auto& c = s2.seedCells();
         const auto expect = std::vector { std::size_t{1729} };
 
@@ -208,10 +241,10 @@ BOOST_AUTO_TEST_CASE(Assignment_Operator)
 BOOST_AUTO_TEST_CASE(Move_Assignment_Operator)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.7, 2.9 });
 
     auto s2 = Opm::WellFractureSeeds { "W2" };
-    s2.updateSeed(2718, NormalVector { 0.0, -1.0, 0.0 });
+    s2.updateSeed(2718, NormalVector { 0.0, -1.0, 0.0 }, SizeVector { 31.415, 9.2653 });
 
     s2 = std::move(seeds);
 
@@ -235,6 +268,14 @@ BOOST_AUTO_TEST_CASE(Move_Assignment_Operator)
     }
 
     {
+        const auto* s = s2.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.7, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.9, 1.0e-8);
+    }
+
+    {
         const auto& c = s2.seedCells();
         const auto expect = std::vector { std::size_t{1729} };
 
@@ -245,7 +286,7 @@ BOOST_AUTO_TEST_CASE(Move_Assignment_Operator)
 BOOST_AUTO_TEST_CASE(Request_Missing_Seed)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 0.1, 2.3 });
 
     BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
 
@@ -254,20 +295,30 @@ BOOST_AUTO_TEST_CASE(Request_Missing_Seed)
         BOOST_CHECK_MESSAGE(n == nullptr, "Normal vector in non-existing seed cell must be null");
     }
 
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 271828 });
+        BOOST_CHECK_MESSAGE(s == nullptr, "Size vector in non-existing seed cell must be null");
+    }
+
     seeds.finalizeSeeds();
 
     {
         const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 314159 });
         BOOST_CHECK_MESSAGE(n == nullptr, "Normal vector in non-existing seed cell must be null");
     }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 314159 });
+        BOOST_CHECK_MESSAGE(s == nullptr, "Size vector in non-existing seed cell must be null");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(Multiple_Seeds)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
-    seeds.updateSeed(1122, NormalVector { 0.0, 1.0, 0.0 });
-    seeds.updateSeed(3344, NormalVector { 0.0, 0.0, 1.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 12.34, 5.67 });
+    seeds.updateSeed(1122, NormalVector { 0.0, 1.0, 0.0 }, SizeVector { 1.234, 56.7 });
+    seeds.updateSeed(3344, NormalVector { 0.0, 0.0, 1.0 }, SizeVector { 123.4, 0.567 });
 
     BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{3});
 
@@ -296,6 +347,30 @@ BOOST_AUTO_TEST_CASE(Multiple_Seeds)
         BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 12.34, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1],  5.67, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0],  1.234, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 56.7  , 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 123.4  , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1],   0.567, 1.0e-8);
     }
 
     {
@@ -362,6 +437,30 @@ BOOST_AUTO_TEST_CASE(Multiple_Seeds)
         BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 12.34, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1],  5.67, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0],  1.234, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 56.7  , 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 123.4  , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1],   0.567, 1.0e-8);
     }
 
     {
@@ -409,9 +508,13 @@ BOOST_AUTO_TEST_SUITE(Insert_Duplicate)
 BOOST_AUTO_TEST_CASE(Different_Normal_Vectors)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.1, 2.2 });
 
-    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 0.0, -1.0, 0.0 }),
+    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 0.0, -1.0, 0.0 }, SizeVector { 1.1, 2.2 }),
+                        "Updating seed with different "
+                        "normal vector must succeed");
+
+    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 0.0, -1.0, 0.0 }, SizeVector { 1.7, 2.9 }),
                         "Updating seed with different "
                         "normal vector must succeed");
 
@@ -424,6 +527,14 @@ BOOST_AUTO_TEST_CASE(Different_Normal_Vectors)
         BOOST_CHECK_CLOSE((*n)[0],  0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], -1.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2],  0.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.7, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.9, 1.0e-8);
     }
 
     {
@@ -452,6 +563,14 @@ BOOST_AUTO_TEST_CASE(Different_Normal_Vectors)
         BOOST_CHECK_CLOSE((*n)[0],  0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], -1.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2],  0.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.7, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.9, 1.0e-8);
     }
 
     {
@@ -473,11 +592,12 @@ BOOST_AUTO_TEST_CASE(Different_Normal_Vectors)
 BOOST_AUTO_TEST_CASE(Same_Normal_Vector)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.1, 2.2 });
 
-    BOOST_CHECK_MESSAGE(! seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }),
+    BOOST_CHECK_MESSAGE(! seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.1, 2.2 }),
                         "Updating seed with same "
-                        "normal vector must NOT succeed");
+                        "normal and size vectors "
+                        "must NOT succeed");
 
     BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
 
@@ -488,6 +608,14 @@ BOOST_AUTO_TEST_CASE(Same_Normal_Vector)
         BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.1, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.2, 1.0e-8);
     }
 
     {
@@ -519,6 +647,14 @@ BOOST_AUTO_TEST_CASE(Same_Normal_Vector)
     }
 
     {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.1, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 2.2, 1.0e-8);
+    }
+
+    {
         const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
 
         BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
@@ -537,10 +673,10 @@ BOOST_AUTO_TEST_CASE(Same_Normal_Vector)
 BOOST_AUTO_TEST_CASE(Multiple_Seeds_Different_Normals)
 {
     auto seeds = Opm::WellFractureSeeds { "W1" };
-    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
-    seeds.updateSeed(1122, NormalVector { 0.0, 1.0, 0.0 });
-    seeds.updateSeed(3344, NormalVector { 0.0, 0.0, 1.0 });
-    seeds.updateSeed(1729, NormalVector { 0.0, 0.0, 1.1 });
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }, SizeVector { 1.7, 2.9 });
+    seeds.updateSeed(1122, NormalVector { 0.0, 1.0, 0.0 }, SizeVector { 1.6, 1.8 });
+    seeds.updateSeed(3344, NormalVector { 0.0, 0.0, 1.0 }, SizeVector { 2.7, 1.82 });
+    seeds.updateSeed(1729, NormalVector { 0.0, 0.0, 1.1 }, SizeVector { 3.3, 4.4 });
 
     BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{3});
 
@@ -554,6 +690,14 @@ BOOST_AUTO_TEST_CASE(Multiple_Seeds_Different_Normals)
     }
 
     {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 3.3, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 4.4, 1.0e-8);
+    }
+
+    {
         const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1122 });
         BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
 
@@ -563,12 +707,28 @@ BOOST_AUTO_TEST_CASE(Multiple_Seeds_Different_Normals)
     }
 
     {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.6, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 1.8, 1.0e-8);
+    }
+
+    {
         const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 3344 });
         BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
 
         BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 2.7 , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 1.82, 1.0e-8);
     }
 
     {
@@ -620,6 +780,14 @@ BOOST_AUTO_TEST_CASE(Multiple_Seeds_Different_Normals)
     }
 
     {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 3.3, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 4.4, 1.0e-8);
+    }
+
+    {
         const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1122 });
         BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
 
@@ -629,12 +797,28 @@ BOOST_AUTO_TEST_CASE(Multiple_Seeds_Different_Normals)
     }
 
     {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 1.6, 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 1.8, 1.0e-8);
+    }
+
+    {
         const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 3344 });
         BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
 
         BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
         BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto* s = seeds.getSize(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(s != nullptr, "Size vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*s)[0], 2.7 , 1.0e-8);
+        BOOST_CHECK_CLOSE((*s)[1], 1.82, 1.0e-8);
     }
 
     {


### PR DESCRIPTION
In particular, account for new `seedSize` parameter in member function `WellFractureSeeds::updateSeeds()`, include the new `seedSize_` member in the serialisation function, and fix test `MECH` keyword requirement test that no longer applies.

While here, also fix a misprint in `StressEquilRecord::operator==()` which generated false negatives in the serialisation test.