### PR TITLE
Support Additional Water Injection Vectors for Fracture

### DIFF
--- a/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -98,6 +98,9 @@ namespace {
 
             // Filtrate injection volumes.
             "FCFFVIT", "FCFVIT", "FCFWVIT",
+
+            // Water injection volumes in fracture.
+            "WITFRAC",
         };
 
         auto sep_pos = key.find(':');

--- a/opm/input/eclipse/share/keywords/900_OPM/C/CONNECTION_PROBE_OPM
+++ b/opm/input/eclipse/share/keywords/900_OPM/C/CONNECTION_PROBE_OPM
@@ -84,7 +84,9 @@
     "CMUPR",
     "CMUPT",
     "CMUPRL",
-    "CMUPTL"
+    "CMUPTL",
+    "CWIRFRAC",
+    "CWITFRAC"
   ],
   "items": [
     {

--- a/opm/input/eclipse/share/keywords/900_OPM/W/WELL_PROBE_OPM
+++ b/opm/input/eclipse/share/keywords/900_OPM/W/WELL_PROBE_OPM
@@ -34,7 +34,8 @@
       "WMOPT",
       "WMUPR",
       "WMUPT",
-      "WWIRFRAC"
+      "WWIRFRAC",
+      "WWITFRAC"
   ],
   "size": 1,
   "items": [

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -2491,6 +2491,7 @@ static const auto funs = std::unordered_map<std::string, ofun> {
     { "WWIGR", well_guiderate<injector, Opm::data::GuideRateValue::Item::Water> },
 
     { "WWIT", mul( rate< rt::wat, injector >, duration ) },
+    { "WWITFRAC", mul(rate<rt::wat_frac, injector>, duration) },
     { "WOIT", mul( rate< rt::oil, injector >, duration ) },
     { "WGIT", mul( rate< rt::gas, injector >, duration ) },
     { "WEIT", mul( rate< rt::energy, injector >, duration ) },
@@ -2859,6 +2860,7 @@ static const auto funs = std::unordered_map<std::string, ofun> {
     { "CWCTL", div( cratel< rt::wat, producer >,
                     sum( cratel< rt::wat, producer >, cratel< rt::oil, producer > ) ) },
     { "CWIR", crate< rt::wat, injector > },
+    { "CWIRFRAC", crate<rt::wat_frac, injector> },
     { "CGIR", crate< rt::gas, injector > },
     { "COIR", crate< rt::oil, injector > },
     { "CVIR", crate_resv<injector> },
@@ -2964,6 +2966,7 @@ static const auto funs = std::unordered_map<std::string, ofun> {
 
     { "COIT", mul( crate< rt::oil, injector >, duration ) },
     { "CWIT", mul( crate< rt::wat, injector >, duration ) },
+    { "CWITFRAC", mul(crate<rt::wat_frac, injector>, duration) },
     { "CGIT", mul( crate< rt::gas, injector >, duration ) },
     { "CVIT", mul( crate_resv<injector>, duration ) },
     { "CNIT", mul( crate< rt::solvent, injector >, duration ) },


### PR DESCRIPTION
This PR adds support for the following new water injection summary vectors for analysing the fractions attributable to fracture flow

  - `CWIRFRAC`&ndash;Connection level water injection rate in fracture
  - `CWITFRAC`&ndash;Connection level cumulative injection volume in fracture
  - `WWITFRAC`&ndash;Well level cumulative injection volume in fracture

The vectors depend on client code populating `Rates::opt::wat_frac` items at the connection and well levels.